### PR TITLE
remove std::span from mem.hpp

### DIFF
--- a/src/core/gba.cpp
+++ b/src/core/gba.cpp
@@ -163,6 +163,8 @@ auto Gba::loadbios(std::span<const u8> new_bios) -> bool
         return false;
     }
 
+    // std::copy()
+    // std::ranges::copy()
     std::ranges::copy(new_bios, this->bios);
     this->has_bios = true;
 

--- a/src/core/gba.cpp
+++ b/src/core/gba.cpp
@@ -163,8 +163,6 @@ auto Gba::loadbios(std::span<const u8> new_bios) -> bool
         return false;
     }
 
-    // std::copy()
-    // std::ranges::copy()
     std::ranges::copy(new_bios, this->bios);
     this->has_bios = true;
 

--- a/src/core/mem.hpp
+++ b/src/core/mem.hpp
@@ -4,19 +4,18 @@
 #pragma once
 
 #include "fwd.hpp"
-#include <span>
 
 namespace gba::mem {
 
 struct ReadArray
 {
-    std::span<const u8> array;
+    const u8* array;
     u32 mask;
 };
 
 struct WriteArray
 {
-    std::span<u8> array;
+    u8* array;
     u32 mask;
 };
 


### PR DESCRIPTION
TODO: benchmark msvc, clang, gcc etc...

size differences (sdl2 preset build)
// span:	457.3 KiB (468,240)
// carray:	453.3 KiB (464,176)